### PR TITLE
Dockerise app for development

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,19 +1,2 @@
-FROM node:8
-
-# Create app directory
-WORKDIR /usr/src/app
-
-# Install app dependencies
-# A wildcard is used to ensure both package.json AND package-lock.json are copied
-# where available (npm@5+)
-COPY package*.json ./
-
-RUN npm install
-# If you are building your code for production
-# RUN npm ci --only=production
-
-# Bundle app source
-COPY . .
-
-EXPOSE 8080
-CMD [ "npm", "start" ]
+FROM node:6
+WORKDIR /code

--- a/bin/docker-command.bash
+++ b/bin/docker-command.bash
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+# crash on error:
+set -e
+
+# install dependencies
+npm install
+# serve with hot reload at localhost:8080
+npm run dev

--- a/config/index.js
+++ b/config/index.js
@@ -13,7 +13,7 @@ module.exports = {
     proxyTable: {},
 
     // Various Dev Server settings
-    host: 'localhost', // can be overwritten by process.env.HOST
+    host: '0.0.0.0', // can be overwritten by process.env.HOST
     port: 8080, // can be overwritten by process.env.PORT, if port is in use, a free one will be determined
     autoOpenBrowser: false,
     errorOverlay: true,
@@ -23,7 +23,7 @@ module.exports = {
     // Use Eslint Loader?
     // If true, your code will be linted during bundling and
     // linting errors and warnings will be shown in the console.
-    useEslint: true,
+    useEslint: false,
     // If true, eslint errors and warnings will also be shown in the error overlay
     // in the browser.
     showEslintErrorsInOverlay: false,

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,12 @@
+version: '3'
+
+services:
+  web:
+    environment:
+      - CHOKIDAR_USEPOLLING=true # for hot reloading on Windows
+    build: .
+    volumes:
+      - .:/code
+    command: ./bin/docker-command.bash
+    ports:
+      - "8080:8080"


### PR DESCRIPTION
I added:
* A Dockerfile: this still inherits from `node:6` as it looks like the original app was made for that version. By now Node 10 is out, so that's a little behind.
* The `docker-compose` file specifies the Docker environment. No need for countless many flags in `docker run -it ... -v ...`, just simply run `docker-compose up` and you're done
* In `config/index.js` I updated the server to `0.0.0.0`. On some machines/operating systems that's identical to `localhost`, but here it didn't work. 
* The `bin/docker-command.bash` specifies the commands that need to be run to spin up the server.